### PR TITLE
Automate releases and documentation publishing

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,68 +1,15 @@
 name: Release to PyPI
 
 on:
-  pull_request:
-    types:
-      - closed
-    branches:
-      - master
+  push:
+    tags:
+      - "v*"
   workflow_dispatch:
-    inputs:
-      release_type:
-        description: Version component to bump before publishing
-        required: false
-        default: patch
-        type: choice
-        options:
-          - patch
-          - minor
-          - major
-
-permissions:
-  contents: write
 
 jobs:
-  bump_version:
-    name: Bump version
-    runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
-    outputs:
-      version: ${{ steps.bump.outputs.version }}
-      tag: ${{ steps.bump.outputs.tag }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: master
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
-      - name: Bump project version
-        id: bump
-        env:
-          RELEASE_TYPE: ${{ github.event.inputs.release_type || 'patch' }}
-        run: |
-          version=$(python scripts/bump_version.py --part "${RELEASE_TYPE}")
-          echo "version=${version}" >> "${GITHUB_OUTPUT}"
-          echo "tag=v${version}" >> "${GITHUB_OUTPUT}"
-
-      - name: Commit and tag release
-        env:
-          VERSION: ${{ steps.bump.outputs.version }}
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add coilpy/__init__.py meson.build
-          git commit -m "chore: bump version to ${VERSION}"
-          git tag "v${VERSION}"
-          git push origin HEAD:master --follow-tags
-
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
-    needs: bump_version
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -71,7 +18,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ needs.bump_version.outputs.tag }}
+          fetch-depth: 0
+          ref: ${{ github.ref }}
 
       # Used to host cibuildwheel
       - uses: actions/setup-python@v5
@@ -106,14 +54,14 @@ jobs:
 
   make_sdist:
     name: Make SDist
-    needs: bump_version
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
       with:
-        ref: ${{ needs.bump_version.outputs.tag }}
         fetch-depth: 0  # Optional, use if you use setuptools_scm
         submodules: true  # Optional, use if you have submodules
+        ref: ${{ github.ref }}
 
     - name: Install build frontend
       run: python -m pip install build
@@ -129,7 +77,8 @@ jobs:
   pypi-publish:
     name: Upload release to PyPI
     runs-on: ubuntu-latest
-    needs: [bump_version, build_wheels, make_sdist]
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    needs: [build_wheels, make_sdist]
     environment:
       name: pypi
       url: https://pypi.org/p/coilpy

--- a/.github/workflows/release-bump.yml
+++ b/.github/workflows/release-bump.yml
@@ -1,0 +1,57 @@
+name: Release Bump
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - master
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: Version component to bump before tagging
+        required: false
+        default: patch
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+permissions:
+  contents: write
+
+jobs:
+  bump_version:
+    name: Bump version and tag
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: master
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Bump project version
+        id: bump
+        env:
+          RELEASE_TYPE: ${{ github.event.inputs.release_type || 'patch' }}
+        run: |
+          version=$(python scripts/bump_version.py --part "${RELEASE_TYPE}")
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+
+      - name: Commit and tag release
+        env:
+          VERSION: ${{ steps.bump.outputs.version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add coilpy/__init__.py meson.build
+          git commit -m "chore: bump version to ${VERSION}"
+          git tag "v${VERSION}"
+          git push origin HEAD:master --follow-tags


### PR DESCRIPTION
## Summary
- add automated release bumping and tag-driven PyPI publishing workflows
- add a GitHub Pages documentation workflow and expand the Sphinx docs landing pages
- clean up local validation support, including dev dependencies and test/doc fixes
- fix the `FourSurf.read_winding_surfce` typo by introducing `read_winding_surface` with a compatibility shim

## Validation
- built the Sphinx site locally with the project `.venv`
- ran `test/coil/test_coil.py` locally with a headless matplotlib backend
- checked the workflow YAML files for parse errors

## Notes
- the release workflow was split so merge-to-master bumps and tags first, then PyPI publishing runs from the pushed `v*` tag to avoid the checkout race on newly created tags